### PR TITLE
Fix issue with Afraid.org hashes are being truncated.

### DIFF
--- a/src/router/httpd/validate/webs.c
+++ b/src/router/httpd/validate/webs.c
@@ -3435,10 +3435,13 @@ char *request_freedns(char *user, char *password)
 		free(hash);
 		return NULL;
 	}
-	for (i = 0; i < 36; i++)
+	for (i = 0; i < 63 && feof(in) == 0; i++) {
 		hash[i] = getc(in);
+      if (hash[i] == EOF)
+        break;
+    }
 	fclose(in);
-	hash[i++] = 0;
+	hash[i] = 0;
 	return hash;
 }
 


### PR DESCRIPTION
The problem is that the return value hashes to http://freedns.afraid.org/api/?action=getdyndns&sha=[SHA1]
is > 36 characters (i.e. 44).  We should try to read to the end of the file.

Reported since 2010 in: http://www.dd-wrt.com/phpBB2/viewtopic.php?p=781615
