### PR TITLE
Remove openvpn client auth character limits

### DIFF
--- a/src/router/openvpn/config/openvpncl.webvpn
+++ b/src/router/openvpn/config/openvpncl.webvpn
@@ -116,11 +116,11 @@
 		<div id="idupauth">
 			<div class="setting">
 				<div class="label"><% tran("share.usrname"); %></div>
-				 <input size="32" maxlength="32" class="text" name="openvpncl_user" value="<% nvg("openvpncl_user"); %>" />
+				 <input size="32" class="text" name="openvpncl_user" value="<% nvg("openvpncl_user"); %>" />
 			</div>
 			<div class="setting">
 				<div class="label"><% tran("share.passwd"); %></div>
-				<input size="32" maxlength="32" class="text" name="openvpncl_pass" value="<% nvg("openvpncl_pass"); %>" />
+				<input size="32" class="text" name="openvpncl_pass" value="<% nvg("openvpncl_pass"); %>" />
 			</div>
 		</div>
 		<div class="setting">


### PR DESCRIPTION
Hello there,

Submitting a pull request so folks don't beat their heads against their desk like I just did.

The GUI does not allow username or passwords longer than 32 characters. When copy/pasting into the GUI, a user (myself included) will not notice their input was truncated and spend the next couple hours trying to figure out why they have an `AUTH: Received control message: AUTH_FAILED` message in their logs.

As a test, I removed the `maxlength` attribute through the DOM editor, updated my username with a 36 character username and had no issues.

Thanks!