### PR TITLE
Themes and related changes to help pages/contents

### DIFF
--- a/src/router/httpd/modules/base.c
+++ b/src/router/httpd/modules/base.c
@@ -2514,7 +2514,7 @@ static int do_syslog(unsigned char method, struct mime_handler *handler, char *u
 						   || strstr(line, "httpd login failure")
 						   || strstr(line, "auth-failure")
 						   || strstr(line, ".err")) {
-						websWrite(stream, "<tr bgcolor=\"#ea0707\" color=\"#eeeeee\"><td>%s</td></tr>", line);
+						websWrite(stream, "<tr bgcolor=\"#ea0707\"><td style=\"color=\"#eeeeee\"\">%s</td></tr>", line);
 					} else {
 						websWrite(stream, "<tr><td>%s</td></tr>", line);
 					}

--- a/src/router/httpd/validate/validators.c
+++ b/src/router/httpd/validate/validators.c
@@ -2391,7 +2391,7 @@ EJ_VISIBLE void validate_staticleases(webs_t wp, char *value, struct variable *v
 
 		if (mac == NULL) {
 			free(leases);
-			websError(wp, 400, "%s is not a valid mac adress\n", hwaddr);
+			websError(wp, 400, "%s is not a valid MAC adress\n", hwaddr);
 			return;
 		}
 		snprintf(lease_hostname, sizeof(lease_hostname), "lease%d_hostname", i);

--- a/src/router/kromo/dd-wrt/blue/style.css
+++ b/src/router/kromo/dd-wrt/blue/style.css
@@ -41,9 +41,15 @@ fieldset legend {
 }
 input.button {
   background: #36f;
+  border: 1px solid #4171ff;
   color: #f8f8f8;
 }
 input.button:hover {
   background: #5781ff;
+  border: 1px solid #5781ff;
   color: #fff;
+}
+input:focus-visible, textarea:focus-visible {
+  box-shadow: 0 0 5px 1px #5781ff !important;
+  outline: 2px solid #5781ff !important;
 }

--- a/src/router/kromo/dd-wrt/common_backup/common.js
+++ b/src/router/kromo/dd-wrt/common_backup/common.js
@@ -727,7 +727,7 @@ function openHelpWindowExt(url) {
 	var left = Math.floor(screen.availWidth * .66) - 10;
 	var width = Math.floor(screen.availWidth * .33);
 	var height = Math.floor(screen.availHeight * .9) - 30;
-	var win = window.open("http://www.dd-wrt.com/help/english/" + url, 'DDWRT_Help', 'top=' + top + ',left=' + left + ',width=' + width + ',height=' + height + ",resizable=yes,scrollbars=yes,statusbar=no");
+	var win = window.open("https://forum.dd-wrt.com/wiki/index.php/Main_Page" + url, 'DDWRT_Help', 'top=' + top + ',left=' + left + ',width=' + width + ',height=' + height + ",resizable=yes,scrollbars=yes,statusbar=no");
 	win.focus();
 }
 
@@ -1015,7 +1015,7 @@ function applytake(form, text,seconds, delay) {
 		
 		if(delay) {
 			setTimeout(function(){infoTimeout(text,seconds, delay);}, 1000);
-    		}
+    }
 	}
 }
 

--- a/src/router/kromo/dd-wrt/common_style/common.css
+++ b/src/router/kromo/dd-wrt/common_style/common.css
@@ -3,7 +3,7 @@
   font-size: 1em;
 }
 body {
-  background: #fff;
+  background: #f9f9f9;
   margin: .906em;
   font-size: 69%;
 }
@@ -23,15 +23,15 @@ pre {
   overflow: auto;
   padding: 1em;
   margin: 0;
-  font-family: "Courier New", Courier, monospace;
+  font-family: 'Courier New', Courier, monospace;
   background-color: #f7f7f7;
   white-space: pre-wrap;
 }
 form {
   margin: 0;
 }
-form[name="wds"] select {
-	margin-right: 6px;
+form[name='wds'] select {
+  margin-right: 6px;
 }
 input.num {
   padding-left: 1px;
@@ -240,7 +240,7 @@ fieldset legend {
   font-weight: bold;
   margin-left: -.362em;
   padding: 0 .272em;
-  background: #fff;
+  background: #f9f9f9;
 }
 table {
   margin: 0 auto;
@@ -262,7 +262,7 @@ table tr:hover {
   background: #e8e8e8;
 }
 table tr:not([bgcolor]):hover {
-  background-color: #fff;
+  background-color: #f9f9f9;
 }
 table td {
   padding: 0;
@@ -377,15 +377,11 @@ td .meter {
   background: url(/images/bin_bt.gif) center no-repeat;
   cursor: pointer;
 }
-body input.button {
+input.button {
   padding: .2em .362em;
   margin: 0 .3em 0 0;
   cursor: pointer;
-  border-width: 1px;
-  border-bottom-color: #ccc;
-  border-right-color: #ccc;
-  border-left-color: #ddd;
-  border-top-color: #ddd;
+  border: 1px solid #ccc;
 }
 body input.button[disabled] {
   cursor: default;
@@ -411,7 +407,7 @@ input.four_column {
 input.four_column_last {
   margin-right: 0;
 }
-input.button[onclick*="delete"] {
+input.button[onclick*='delete'] {
   margin: 0 .4em 0 .4em;
 }
 div.bulle {
@@ -453,7 +449,7 @@ td.bulle {
   text-align: center;
 }
 .off {
-  background: #e0e0e0;
+  opacity: .6;
 }
 .odd {
   background: #ccc;

--- a/src/router/kromo/dd-wrt/cyan/style.css
+++ b/src/router/kromo/dd-wrt/cyan/style.css
@@ -2,17 +2,17 @@
 #menuSub, #menuMainList li span, #help h2 {
   background: #099;
   color: #fff;
-  border-color: #3bb #066 #066 #3bb;
+  border-color: #3bb;
 }
 #menuSubList li a {
   background: #3bb;
   color: #cff;
-  border-color: #4cc #1aa #1aa #4cc;
+  border-color: #4cc;
 }
 #menuSubList li a:hover {
   background: #6cc;
   color: #fff;
-  border-color: #8dd #5bb #5bb #8dd;
+  border-color: #8dd;
 }
 fieldset legend {
   color: #099;
@@ -41,9 +41,15 @@ fieldset legend {
 }
 input.button {
   background: #3bb;
+  border: 1px solid #3bb;
   color: #cff;
 }
 input.button:hover {
   background: #6cc;
+  border: 1px solid #6cc;
   color: #fff;
+}
+input:focus-visible, textarea:focus-visible {
+  box-shadow: 0 0 5px 1px #6cc !important;
+  outline: 2px solid #6cc !important;
 }

--- a/src/router/kromo/dd-wrt/elegant/fresh-dark.css
+++ b/src/router/kromo/dd-wrt/elegant/fresh-dark.css
@@ -24,9 +24,7 @@ body div.progressbar {
   border-radius: 4px;
   border: 1px solid #333;
 }
-body input.button {
-  background: #36f;
-  border: 1px solid #4171ff;
+input.button {
   color: #eee;
   box-shadow: none;
 }
@@ -81,11 +79,9 @@ body input[disabled], body select[disabled] {
   border-color: #111;
 }
 body input[name="save_button"] {
-  border-color: #4171ff;
   color: #eee;
 }
 body input[name="save_button"]:hover {
-  border-color: #78f;
   color: #fff;
 }
 body input[name="apply_button"] {

--- a/src/router/kromo/dd-wrt/elegant/fresh-dark.css
+++ b/src/router/kromo/dd-wrt/elegant/fresh-dark.css
@@ -45,24 +45,6 @@ body #content.infopage #main {
   background-color: #1a1a1a;
   border: 1px solid #333;
 }
-.help-bg a {
-  color: #0087ff;
-}
-.help-bg #content {
-  color: #999;
-  background: transparent;
-  border: 1px solid transparent;
-}
-.about-bg, .help-bg {
-  background: #1a1a1a;
-  color: #eee;
-}
-.about-bg #content {
-  border-color: transparent;
-}
-.about-bg #content .t-border {
-  border-color: #333;
-}
 #header .logo {
   filter: invert(.95) hue-rotate(180deg);
   mix-blend-mode: lighten;
@@ -112,8 +94,8 @@ body input[name="apply_button"] {
   color: #fff;
 }
 body input[name="apply_button"]:hover {
-  background: none repeat scroll 0 0 #25b545;
-  border-color: #25b545;
+  background: none repeat scroll 0 0 #199235;
+  border-color: #199235;
   color: #fff;
 }
 body input[name="reset_button"] {
@@ -122,19 +104,19 @@ body input[name="reset_button"] {
   color: #ccc;
 }
 body input[name="reset_button"]:hover {
-  background: none repeat scroll 0 0 #d38f12;
-  border-color: #d38f12;
+  background: none repeat scroll 0 0 #d6951e;
+  border-color: #d0911d;
   color: #fff;
 }
 body input[name="reboot_button"] {
-  background: none repeat scroll 0 0 #f00;
-  border-color: #f00;
-  color: #fff;
+  background: none repeat scroll 0 0 #c11616;
+  border-color: #c11616;
+  color: #f8f8f8;
 }
 body input[name="reboot_button"]:hover {
-  background: none repeat scroll 0 0 #e14242;
-  border-color: #e14242;
-  color: #f8f8f8;
+  background: none repeat scroll 0 0 #d82828;
+  border-color: #d82828;
+  color: #fff;
 }
 input.button[onclick*="delete"] {
   margin: 0 .2em 0 .4em;
@@ -213,15 +195,4 @@ fieldset.off {
 .warning {
   background: #351212;
   border-color: #b53030;
-}
-div.note {
-  background: #380c55;
-  border-color: #8030b5;
-  margin-top: .5rem;
-  border-radius: 4px;
-}
-div.also {
-  background: #1a1a1a;
-  border-color: #333;
-  border-radius: 4px;
 }

--- a/src/router/kromo/dd-wrt/elegant/fresh.css
+++ b/src/router/kromo/dd-wrt/elegant/fresh.css
@@ -88,36 +88,43 @@ input.button {
   height: 1.6rem;
   vertical-align: middle;
   box-shadow: 2px 2px 2px #808080;
+  border-color: #ccc;
 }
 input.button[name='preview_button'] {
   padding: 0 .6rem 0 .6rem;
 }
 input[name='apply_button'] {
   background: none repeat scroll 0 0 #696969;
+  border-color: #ccc;
   color: #fff;
 }
 input[name='apply_button']:hover {
   background: none repeat scroll 0 0 #777674;
+  border-color: #ccc;
   color: #000;
 }
 input[name='reset_button'] {
   background: none repeat scroll 0 0 #fff;
+  border-color: #ccc;
   color: #000;
 }
 input[name='reset_button']:hover {
   background: none repeat scroll 0 0 #ffa500;
+  border-color: #ccc;
   color: #000;
 }
 input[name='reboot_button'] {
   background: none repeat scroll 0 0 #f00;
+  border-color: #ccc;
   color: #fff;
 }
 input[name='reboot_button']:hover {
   background: none repeat scroll 0 0 #ff7c7c;
+  border-color: #ccc;
   color: #000;
 }
 input:focus, input.focus {
-  border: solid 1px #707070;
+  border: 1px solid #707070;
   box-shadow: 0 0 5px 1px #969696;
 }
 input.button[disabled] {
@@ -128,6 +135,9 @@ input.button[disabled] {
 }
 input.num {
   vertical-align: middle;
+}
+input.num[name*='lease'][size='10'] {
+	margin-right: 4px;
 }
 select {
   padding: 4px 4px;
@@ -206,7 +216,7 @@ form[name='wds'] select {
   border-width: 2px;
 }
 .off {
-  background-color: #e0e0e0;
+  opacity: .6;
 }
 .odd {
   background-color: #f1f1f1;

--- a/src/router/kromo/dd-wrt/elegant/help-about-dark.css
+++ b/src/router/kromo/dd-wrt/elegant/help-about-dark.css
@@ -1,0 +1,29 @@
+.about-bg, .help-bg {
+  background: #1a1a1a;
+  color: #eee;
+}
+.help-bg a {
+  color: #0087ff;
+}
+.help-bg #content {
+  color: #999;
+  background: transparent;
+  border: 1px solid transparent;
+}
+.about-bg #content {
+  border-color: transparent;
+}
+.about-bg #content .t-border {
+  border-color: #333;
+}
+div.note {
+  background: #380c55;
+  border-color: #8030b5;
+  margin-top: .5rem;
+  border-radius: 4px;
+}
+div.also {
+  background: #1a1a1a;
+  border-color: #333;
+  border-radius: 4px;
+}

--- a/src/router/kromo/dd-wrt/elegant/style.css
+++ b/src/router/kromo/dd-wrt/elegant/style.css
@@ -41,9 +41,15 @@ fieldset legend {
 }
 input.button {
   background: #36f;
+  border: 1px solid #36f;
   color: #fff;
 }
 input.button:hover {
   background: #6384cf;
+  border: 1px solid #6384cf;
   color: #fff;
+}
+input:focus-visible, textarea:focus-visible {
+  box-shadow: 0 0 5px 1px #5781ff !important;
+  outline: 2px solid #5781ff !important;
 }

--- a/src/router/kromo/dd-wrt/green/style.css
+++ b/src/router/kromo/dd-wrt/green/style.css
@@ -2,17 +2,17 @@
 #menuSub, #menuMainList li span, #help h2 {
   background: #090;
   color: #fff;
-  border-color: #3b3 #060 #060 #3b3;
+  border-color: #3b3;
 }
 #menuSubList li a {
   background: #3b3;
   color: #cfc;
-  border-color: #4c4 #1a1 #1a1 #4c4;
+  border-color: #4c4;
 }
 #menuSubList li a:hover {
   background: #6c6;
   color: #fff;
-  border-color: #8d8 #5b5 #5b5 #8d8;
+  border-color: #8d8;
 }
 fieldset legend {
   color: #090;
@@ -41,9 +41,15 @@ fieldset legend {
 }
 input.button {
   background: #3b3;
+  border: 1px solid #3b3;
   color: #cfc;
 }
 input.button:hover {
   background: #6c6;
+  border: 1px solid #6c6;
   color: #fff;
+}
+input:focus-visible, textarea:focus-visible {
+  box-shadow: 0 0 5px 1px #6c6 !important;
+  outline: 2px solid #6c6 !important;
 }

--- a/src/router/kromo/dd-wrt/help/HAlive.asp
+++ b/src/router/kromo/dd-wrt/help/HAlive.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("alive.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HAnchorFree.asp
+++ b/src/router/kromo/dd-wrt/help/HAnchorFree.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("anchorfree.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HBackup.asp
+++ b/src/router/kromo/dd-wrt/help/HBackup.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("config.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HDDNS.asp
+++ b/src/router/kromo/dd-wrt/help/HDDNS.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("ddns.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HDMZ.asp
+++ b/src/router/kromo/dd-wrt/help/HDMZ.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("dmz.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HDefault.asp
+++ b/src/router/kromo/dd-wrt/help/HDefault.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("factdef.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HDiagnostics.asp
+++ b/src/router/kromo/dd-wrt/help/HDiagnostics.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("diag.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HEoIP.asp
+++ b/src/router/kromo/dd-wrt/help/HEoIP.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("eoip.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HFilters.asp
+++ b/src/router/kromo/dd-wrt/help/HFilters.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("filter.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HFirewall.asp
+++ b/src/router/kromo/dd-wrt/help/HFirewall.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("firewall.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HForward.asp
+++ b/src/router/kromo/dd-wrt/help/HForward.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("prforward.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HForwardSpec.asp
+++ b/src/router/kromo/dd-wrt/help/HForwardSpec.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("pforward.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HHotspot.asp
+++ b/src/router/kromo/dd-wrt/help/HHotspot.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("hotspot.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HLighttpd.asp
+++ b/src/router/kromo/dd-wrt/help/HLighttpd.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("lighttpd.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HManagement.asp
+++ b/src/router/kromo/dd-wrt/help/HManagement.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("management.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HMilkfish.asp
+++ b/src/router/kromo/dd-wrt/help/HMilkfish.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("bmenu.servicesMilkfish"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HNAS.asp
+++ b/src/router/kromo/dd-wrt/help/HNAS.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("nas.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HNetworking.asp
+++ b/src/router/kromo/dd-wrt/help/HNetworking.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("bmenu.networking"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HPPPoE_Server.asp
+++ b/src/router/kromo/dd-wrt/help/HPPPoE_Server.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("service.pppoesrv_legend"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HPPTP.asp
+++ b/src/router/kromo/dd-wrt/help/HPPTP.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("service.pptp_legend"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HPrivoxy.asp
+++ b/src/router/kromo/dd-wrt/help/HPrivoxy.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("privoxy.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HQos.asp
+++ b/src/router/kromo/dd-wrt/help/HQos.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("qos.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HRouting.asp
+++ b/src/router/kromo/dd-wrt/help/HRouting.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("route.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HServices.asp
+++ b/src/router/kromo/dd-wrt/help/HServices.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("service.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HSetup.asp
+++ b/src/router/kromo/dd-wrt/help/HSetup.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("idx.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HStatus.asp
+++ b/src/router/kromo/dd-wrt/help/HStatus.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("status_router.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HStatusLan.asp
+++ b/src/router/kromo/dd-wrt/help/HStatusLan.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("status_lan.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HStatusWireless.asp
+++ b/src/router/kromo/dd-wrt/help/HStatusWireless.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("status_wireless.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HTrigger.asp
+++ b/src/router/kromo/dd-wrt/help/HTrigger.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("trforward.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HUPnP.asp
+++ b/src/router/kromo/dd-wrt/help/HUPnP.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("upnp.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HUSB.asp
+++ b/src/router/kromo/dd-wrt/help/HUSB.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("usb.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HUpgrade.asp
+++ b/src/router/kromo/dd-wrt/help/HUpgrade.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("upgrad.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HVPN.asp
+++ b/src/router/kromo/dd-wrt/help/HVPN.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("vpn.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HWDS.asp
+++ b/src/router/kromo/dd-wrt/help/HWDS.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wds.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HWPA.asp
+++ b/src/router/kromo/dd-wrt/help/HWPA.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wpa.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HWanMAC.asp
+++ b/src/router/kromo/dd-wrt/help/HWanMAC.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wanmac.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HWireless.asp
+++ b/src/router/kromo/dd-wrt/help/HWireless.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wl_basic.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HWirelessAdvanced.asp
+++ b/src/router/kromo/dd-wrt/help/HWirelessAdvanced.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wl_adv.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HWirelessMAC.asp
+++ b/src/router/kromo/dd-wrt/help/HWirelessMAC.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wl_mac.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/HWol.asp
+++ b/src/router/kromo/dd-wrt/help/HWol.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wol.titl"); %>
-	 <body class"help-bg">
+	 <body class="help-bg">
 			<div id="header">
 				 <div class="logo"> </div>
 				 <div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/Hradauth.asp
+++ b/src/router/kromo/dd-wrt/help/Hradauth.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("radius.legend"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 	<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help/index.asp
+++ b/src/router/kromo/dd-wrt/help/index.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("idx.titl"); %>
-	<body class"help-bg">
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HAlive.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HAlive.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("upgrad.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HBackup.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HBackup.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("config.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HDDNS.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HDDNS.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("ddns.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HDMZ.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HDMZ.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("dmz.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HDefault.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HDefault.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("factdef.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HDiagnostics.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HDiagnostics.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("diag.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HEoIP.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HEoIP.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("eoip.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HFilters.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HFilters.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("filter.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HFirewall.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HFirewall.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("firewall.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HForward.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HForward.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("prforward.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HForwardSpec.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HForwardSpec.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("pforward.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HHotspot.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HHotspot.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("hotspot.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HManagement.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HManagement.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("management.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HMilkfish.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HMilkfish.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("bmenu.servicesMilkfish"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>
@@ -43,7 +43,7 @@
 					<div class="note">
 						<h4>Legal</h4>
 						<div>
-						Copyright © 2005-2007 by <a href="http://www.milkfish.org" target="new">The Milkfish Project</a>. All rights reserved.<br />
+						Copyright ï¿½ 2005-2007 by <a href="http://www.milkfish.org" target="new">The Milkfish Project</a>. All rights reserved.<br />
 						Logos and trademarks are the property of their respective owners.<br />
 						The Milkfish software is licensed under the <a href="http://www.gnu.org/licenses/gpl.html" target="new">GNU General Public License</a>.<br />
 						Please note that this software is under development and comes with absolutely no warranty, to the extend permitted by applicable law.</div>

--- a/src/router/kromo/dd-wrt/help_jp/HNetworking.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HNetworking.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("bmenu.networking"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HPPPoE_Server.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HPPPoE_Server.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("service.pppoesrv_legend"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HPPTP.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HPPTP.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("service.pptp_legend"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HQos.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HQos.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("qos.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HRouting.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HRouting.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("route.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HServices.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HServices.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("service.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HSetup.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HSetup.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("idx.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HStatus.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HStatus.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("status_router.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HStatusLan.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HStatusLan.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("status_lan.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HStatusWireless.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HStatusWireless.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("status_wireless.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HTrigger.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HTrigger.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("trforward.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HUPnP.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HUPnP.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("upnp.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HUpgrade.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HUpgrade.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("upgrad.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HVPN.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HVPN.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("vpn.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HWDS.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HWDS.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wds.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HWPA.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HWPA.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wpa.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HWanMAC.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HWanMAC.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wanmac.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HWireless.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HWireless.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wl_basic.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HWirelessAdvanced.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HWirelessAdvanced.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wl_adv.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HWirelessMAC.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HWirelessMAC.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wl_mac.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/HWol.asp
+++ b/src/router/kromo/dd-wrt/help_jp/HWol.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("wol.titl"); %> 
-   <body> 
+   <body class="help-bg">
       <div id="header"> 
          <div class="logo"> </div> 
          <div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div> 

--- a/src/router/kromo/dd-wrt/help_jp/Hradauth.asp
+++ b/src/router/kromo/dd-wrt/help_jp/Hradauth.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("radius.legend"); %>
-	<body>
+	<body class="help-bg">
 	<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="index.asp">Index</a> | <a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/help_jp/index.asp
+++ b/src/router/kromo/dd-wrt/help_jp/index.asp
@@ -1,5 +1,5 @@
 <% do_hpagehead("idx.titl"); %>
-	<body>
+	<body class="help-bg">
 		<div id="header">
 			<div class="logo"> </div>
 			<div class="navig"><a href="javascript:self.close();"><% tran("sbutton.clos"); %></a></div>

--- a/src/router/kromo/dd-wrt/lang_pack/english.js
+++ b/src/router/kromo/dd-wrt/lang_pack/english.js
@@ -1280,6 +1280,9 @@ hidx.auth_dnsmasq="<dd>DHCP-Authoritative should be set when DD-WRT is the only 
 hidx.force_dnsmasq="<dd>This setting causes all port 53 DNS requests from the LAN to external DNS servers to be redirected to DD-WRT's internal DNSmasq server.</dd>";
 hidx.page22="<dd>Select the time zone for your location, or desired location.</dd><dd>Check all values and click <i>Save Settings</i> to save your settings. Click <i>Cancel Changes</i> to cancel your unsaved changes. You can test the settings by connecting to the Internet.</dd>";
 
+var hipv6=new Object();
+hipv6.right2="Internet Protocol version 6 (IPv6) is a network layer IP standard used by electronic devices to exchange data across a packet-switched network. It follows IPv4 as the second version of the Internet Protocol to be formally adopted for general use.";
+
 // ** DSL ** //
 var dsl=new Object();
 dsl.status="DSL Status";

--- a/src/router/kromo/dd-wrt/orange/style.css
+++ b/src/router/kromo/dd-wrt/orange/style.css
@@ -47,3 +47,7 @@ input.button:hover {
   background: #ff9000;
   color: #fff;
 }
+input:focus-visible, textarea:focus-visible {
+  box-shadow: 0 0 5px 1px #ff9000 !important;
+  outline: 2px solid #ff9000 !important;
+}

--- a/src/router/kromo/dd-wrt/red/style.css
+++ b/src/router/kromo/dd-wrt/red/style.css
@@ -41,9 +41,16 @@ fieldset legend {
 }
 input.button {
   background: #d55;
+  border: 1px solid #d55;
   color: #fcc;
 }
 input.button:hover {
   background: #e77;
+  border: 1px solid #e77;
   color: #fff;
 }
+input:focus-visible, textarea:focus-visible {
+  box-shadow: 0 0 5px 1px #e77 !important;
+  outline: 2px solid #e77 !important;
+}
+

--- a/src/router/kromo/dd-wrt/yellow/style.css
+++ b/src/router/kromo/dd-wrt/yellow/style.css
@@ -2,17 +2,17 @@
 #menuSub, #menuMainList li span, #help h2 {
   background: #eec900;
   color: #000;
-  border-color: #ee3 #880 #880 #ee3;
+  border-color: #ee33;
 }
 #menuSubList li a {
   background: #ffd700;
   color: #660;
-  border-color: #ee7 #bb4 #bb4 #ee7;
+  border-color: #ee7;
 }
 #menuSubList li a:hover {
   background: #eec900;
   color: #000;
-  border-color: #ff9 #cc5 #cc5 #ff9;
+  border-color: #ff9;
 }
 fieldset legend {
   color: #eec900;
@@ -41,9 +41,15 @@ fieldset legend {
 }
 input.button {
   background: #eec900;
+  border: 1px solid #eec900;
   color: #660;
 }
 input.button:hover {
   background: #ffd700;
+  border: 1px solid #ffd700;
   color: #000;
+}
+input:focus-visible, textarea:focus-visible {
+  box-shadow: 0 0 5px 1px #ffd700 !important;
+  outline: 2px solid #ffd700 !important;
 }

--- a/src/router/udhcpc/static_leases.c
+++ b/src/router/udhcpc/static_leases.c
@@ -104,9 +104,9 @@ void printStaticLeases(struct static_lease **arg)
 	while(cur != NULL)
 	{
 		/* printf("PrintStaticLeases: Lease mac Address: %x\n", cur->mac); */
-		printf("PrintStaticLeases: Lease mac Value: %x\n", *(cur->mac));
+		printf("PrintStaticLeases: Lease MAC Value: %x\n", *(cur->mac));
 		/* printf("PrintStaticLeases: Lease ip Address: %x\n", cur->ip); */
-		printf("PrintStaticLeases: Lease ip Value: %x\n", *(cur->ip));
+		printf("PrintStaticLeases: Lease IP Value: %x\n", *(cur->ip));
 
 		cur = cur->next;
 	}


### PR DESCRIPTION
Hows it going? Hope you are well., so now running  DD-WRT v3.0-r47528 std (10/10/21)

So Ive fixed some bugs that went past review, @Brainslayer,

## Bugs

1) missed `=` https://github.com/mirror/dd-wrt/commit/7808dd4b15dd1a736b56257c198f9ae6111907d2 asp implementation of <body class="help-bg">

2) related help page additions -> added similar non buggy version to Japanese help pages. https://github.com/mirror/dd-wrt/commit/0261159a5f6ce67c36a484c5d4f97293ce4fbe5e

3) really fixed syslog (try#2)  red background to gray text contrast issue in https://github.com/mirror/dd-wrt/commit/0affa34a711286ce8966fcd0f3071de78dd725db

issue from a long time ago maybe existed for years.

![Capture](https://user-images.githubusercontent.com/31389848/136708308-c4124819-2ee9-4128-9ff3-f9eb47681499.PNG)

after fix (2nd try here, pfff)

![Capture](https://user-images.githubusercontent.com/31389848/136708417-65f4eb50-a9c2-4c5d-8d5b-2ae767a3795c.PNG)

## Changes

1) The dark CSS for the hep and about pages is now its own separate stylesheet lives in
`src/router/kromo/dd-wrt/elegant/help-about-dark.css`

**TODO**

- [ ] This help-about-dark.css be applied when `if("<% nvg("router_style_dark"); %>"=="1")`

2) Classic themes fixes to some older issue and new ones recently introduced due to web UI not loading the most updated versions CSS in new FW version. Likely a local browser cache issue but I cleared everything and still, some old classic themes stylesheets still loaded from before last commit, but not inspired changes ones.

3) Also tried to complete the classic light themes/dark small refresh to try and make this more optimal, need to address some contrast issues, eventually.

Both related: https://github.com/mirror/dd-wrt/commit/7b62e096861df79a428589e42aac7f82c5f8daa4

## Missing help pages and information about existing features.

Not only there are missing help pages there are missing explanations for much of the English text as to many features of dd-wrt

This is a relevant addition towards https://svn.dd-wrt.com/ticket/7478

Because of this and to familiarize myself with methods used to display help pages, I'm trying a small addition https://github.com/mirror/dd-wrt/commit/fcfb862a0e6662cad7f5163971fcf43a82fb24e2

The right2 text belongs to the IPv6 page

![Capture](https://user-images.githubusercontent.com/31389848/136708831-8b2cc1c8-2d7e-4d57-8d79-a93988b30ac8.PNG)

Please check.