### PR TITLE
fixes

### DIFF
--- a/src/router/kromo/dd-wrt/blue/style.css
+++ b/src/router/kromo/dd-wrt/blue/style.css
@@ -30,10 +30,6 @@ fieldset legend {
 .meter .text {
   color: #fff;
 }
-.progressbar {
-  background-color: #fff;
-  border-color: #999;
-}
 .progressbarblock {
   background-color: #36f;
 }

--- a/src/router/kromo/dd-wrt/blue/style.css
+++ b/src/router/kromo/dd-wrt/blue/style.css
@@ -39,18 +39,23 @@ fieldset legend {
 }
 input.button {
   background: #36f;
-  border: 1px solid #4171ff;
-  color: #f8f8f8;
+  border: 1px solid #36f;
+  color: #fff;
 }
-input.button:not([disabled]):hover {
+input.button:hover {
   background: #5781ff;
   border: 1px solid #5781ff;
+  color: #fff;
+}
+input.button[disabled]:hover {
+  background: #36f;
+  border: 1px solid #36f;
   color: #fff;
 }
 input[name*='refresh'][style*='background'] {
   background: #36f !important;
 }
 input:focus-visible, textarea:focus-visible {
-  box-shadow: 0 0 5px 1px #5781ff !important;
-  outline: 2px solid #5781ff !important;
+  box-shadow: 0 0 5px 1px #5781ff;
+  outline: 2px solid #5781ff;
 }

--- a/src/router/kromo/dd-wrt/common_style/common.css
+++ b/src/router/kromo/dd-wrt/common_style/common.css
@@ -19,6 +19,16 @@ hr {
   width: 100%;
   height: .09em;
 }
+textarea {
+  padding: 4px;
+  font-size: 12px;
+  line-height: 1.42857;
+  border-radius: 4px;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+}
 pre {
   overflow: auto;
   padding: 1em;
@@ -33,10 +43,24 @@ form {
 form[name='wds'] select {
   margin-right: 6px;
 }
+input {
+  padding: 4px;
+  font-size: 12px;
+  line-height: 1.42857;
+  border-radius: 4px;
+}
 input.num {
   padding-left: 1px;
   padding-right: 1px;
   text-align: center;
+  vertical-align: middle;
+}
+select {
+  padding: 4px 4px;
+  font-size: 12px;
+  height: 1.6rem;
+  border-radius: 4px;
+  vertical-align: middle;
 }
 #score {
   color: #000;
@@ -227,14 +251,21 @@ fieldset .setting .label {
   font-weight: bold;
   padding: .725em;
   text-align: center;
+  border-radius: 4px;
 }
 fieldset {
   background: #f6f6f6;
   border: 1px solid #ccc;
+  border-radius: 4px;
   padding: .725em;
   margin: 0;
 }
 fieldset legend {
+  padding-bottom: 4px;
+  margin-bottom: 0;
+}
+fieldset legend {
+  left: 0;
   font-weight: bold;
   margin-left: -.362em;
   padding: 0 .272em;
@@ -264,6 +295,15 @@ table tr:not([bgcolor]):hover {
 }
 table td {
   padding: 0;
+}
+table[summary='ports forwarding table'] .num[size='15'] {
+  max-width: 100px;
+}
+table[summary='ports forwarding table'] .num[size='5'] {
+  max-width: 50px;
+}
+table[summary='ports forwarding table'] input[size='10'] {
+  max-width: 79px;
 }
 #help {
   width: 21.333em;
@@ -314,27 +354,22 @@ div.center {
   text-align: center;
 }
 .message {
+  border-radius: 6px;
   max-width: 72.464em;
   margin: 0 auto;
   padding: 1.812em;
   font-weight: bold;
   text-align: center;
-  border-style: solid;
-  border-color: #ddd;
-  border-width: 1px;
-  background: #ccc;
 }
 .message div input {
   margin-top: 1.449em;
   font-weight: normal;
 }
 .popup {
-  background: #f9f9f9;
   padding: .906em;
 }
 .meter {
-  background: #aaa;
-  border: 1px solid #888;
+  border-radius: 3px;
   position: relative;
   float: right;
   margin-top: 1px;
@@ -364,6 +399,7 @@ td .meter {
   border-style: solid;
   font-size: .09em;
   border-width: 1px;
+  border-radius: 4px;
 }
 .progressbarblock {
   position: absolute;
@@ -376,6 +412,22 @@ td .meter {
   background: url(/images/bin_bt.gif) center no-repeat;
   cursor: pointer;
 }
+/*! Find out where this is called from if at all extracted from of fresh.css */
+button {
+  display: inline-block;
+  margin-bottom: 0;
+  font-weight: normal;
+  font-size: 12px;
+  text-align: center;
+  padding: 6px 12px;
+  line-height: 1.42857;
+  cursor: pointer;
+  border-radius: 4px;
+  -moz-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+}
 input.button {
   border: 1px solid #ccc;
   padding: .2em .6em;
@@ -383,6 +435,10 @@ input.button {
   height: 1.6rem;
   vertical-align: middle;
   cursor: pointer;
+}
+input.button:hover, input.button:focus,
+button:hover, button:focus {
+  text-decoration: none;
 }
 body input.button[disabled] {
   cursor: default;
@@ -459,4 +515,5 @@ td.bulle {
 }
 .odd {
   background: #ccc;
+  border-radius: 2px;
 }

--- a/src/router/kromo/dd-wrt/common_style/common_help.css
+++ b/src/router/kromo/dd-wrt/common_style/common_help.css
@@ -103,10 +103,10 @@ div.note {
 }
 div.note h4, div.also h4, div#also a {
   float: left;
-  margin: 0 ;
+  margin: 0;
 }
 div#also a {
-  margin-top: -.7rem
+  margin-top: -.7rem;
 }
 div.note div {
   margin-left: 3.4em;

--- a/src/router/kromo/dd-wrt/cyan/style.css
+++ b/src/router/kromo/dd-wrt/cyan/style.css
@@ -40,17 +40,22 @@ fieldset legend {
 input.button {
   background: #3bb;
   border: 1px solid #3bb;
-  color: #043535;
+  color: #000;
 }
-input.button:not([disabled]):hover {
+input.button:hover {
   background: #6cc;
   border: 1px solid #6cc;
+  color: #000;
+}
+input.button[disabled]:hover {
+  background: #3bb;
+  border: 1px solid #3bb;
   color: #000;
 }
 input[name*='refresh'][style*='background'] {
   background: #3bb !important;
 }
 input:focus-visible, textarea:focus-visible {
-  box-shadow: 0 0 5px 1px #6cc !important;
-  outline: 2px solid #6cc !important;
+  box-shadow: 0 0 5px 1px #6cc;
+  outline: 2px solid #6cc;
 }

--- a/src/router/kromo/dd-wrt/cyan/style.css
+++ b/src/router/kromo/dd-wrt/cyan/style.css
@@ -30,10 +30,6 @@ fieldset legend {
 .meter .text {
   color: #fff;
 }
-.progressbar {
-  background-color: #fff;
-  border-color: #999;
-}
 .progressbarblock {
   background-color: #3bb;
 }

--- a/src/router/kromo/dd-wrt/ddwrt_inspired_themes/core.css
+++ b/src/router/kromo/dd-wrt/ddwrt_inspired_themes/core.css
@@ -106,7 +106,7 @@ body input.button:hover,
 body input.button:focus-within {
   background: var(--v0-7) !important;
   border-color: var(--v0-7) !important;
-  box-shadow: 0 0 10px 0 var(--v0-4);
+  box-shadow: 0 0 10px 0 var(--v0-4) !important;
   color: var(--v9-9);
 }
 body input.button[disabled] {
@@ -114,6 +114,13 @@ body input.button[disabled] {
   border-color: var(--v0-6) !important;
   background-color: var(--v0-5) !important;
   box-shadow: none;
+  opacity: 0.6;
+}
+body input.button[disabled]:hover {
+  color: var(--v9-9) !important;
+  border-color: var(--v0-6) !important;
+  background-color: var(--v0-5) !important;
+  box-shadow: none !important;
   opacity: 0.6;
 }
 body input[name*='apply'] {
@@ -126,7 +133,7 @@ body input[name*='apply']:hover,
 body input[name*='apply']:focus-within {
   background: none repeat scroll 0 0 var(--v4-3) !important;
   border-color: var(--v4-3) !important;
-  box-shadow: 0 0 10px 0 var(--v4-3);
+  box-shadow: 0 0 10px 0 var(--v4-3) !important;
   color: var(--v9-9) !important;
 }
 body input[name*='reset']:not([type="radio"]) {
@@ -139,7 +146,7 @@ body input[name*='reset']:not([type="radio"]):hover,
 body input[name*='reset']:not([type="radio"]):focus-within {
   background: none repeat scroll 0 0 var(--bg-5) !important;
   border-color: var(--bg-5) !important;
-  box-shadow: 0 0 10px 0 var(--bg-5);
+  box-shadow: 0 0 10px 0 var(--bg-5) !important;
   color: var(--v9-9) !important;
 }
 body input[name*='refresh'][style*='background'] {
@@ -155,7 +162,7 @@ body input[name*='reboot']:hover,
 body input[name*='reboot']:focus-within {
   background: none repeat scroll 0 0 var(--v1-6) !important;
   border-color: var(--v1-7) !important;
-  box-shadow: 0 0 10px 0 var(--v1-6);
+  box-shadow: 0 0 10px 0 var(--v1-6) !important;
 }
 body div.progressbar {
   background-color: var(--bg-4);
@@ -870,9 +877,9 @@ input:hover,
 input:focus,
 input:focus-within,
 input:focus-visible {
-  border-color: var(--v0-8) !important;
-  background-color: var(--v0-1) !important;
-  box-shadow: 0 0 6px 0 var(--v0-3) !important;
+  background: var(--v0-1);
+  border-color: var(--v0-8);
+  box-shadow: 0 0 6px 0 var(--v0-3);
   outline: 0 !important;
 }
 input[type='radio'],
@@ -982,7 +989,7 @@ input[type='file']::-webkit-file-upload-button:hover {
   color: 98;
 }
 input[disabled] {
-  opacity: 0.7;
+  opacity: 0.6;
 }
 .off {
   background: var(--bg-2);

--- a/src/router/kromo/dd-wrt/elegant/fresh-dark.css
+++ b/src/router/kromo/dd-wrt/elegant/fresh-dark.css
@@ -16,12 +16,10 @@ body, body.gui, .popup {
 }
 body div.message {
   background-color: #1a1a1a;
-  border-radius: 6px;
   border: 1px solid #333;
 }
 body div.progressbar {
   background-color: #333;
-  border-radius: 4px;
   border: 1px solid #333;
 }
 input.button {

--- a/src/router/kromo/dd-wrt/elegant/fresh.css
+++ b/src/router/kromo/dd-wrt/elegant/fresh.css
@@ -171,6 +171,10 @@ button {
   -moz-user-select: none;
   user-select: none;
 }
+.progressbar {
+  background-color: #fff;
+  border-color: #999;
+}
 #content.infopage {
   background-color: transparent;
 }

--- a/src/router/kromo/dd-wrt/elegant/fresh.css
+++ b/src/router/kromo/dd-wrt/elegant/fresh.css
@@ -122,6 +122,10 @@ input:focus, input.focus {
   border: 1px solid #707070;
   box-shadow: 0 0 5px 1px #969696;
 }
+input.button, input.button:hover {
+	box-shadow: 2px 2px 2px #808080;
+	border-color: #ccc;
+}
 input.button[disabled] {
   cursor: default;
   opacity: .6;

--- a/src/router/kromo/dd-wrt/elegant/fresh.css
+++ b/src/router/kromo/dd-wrt/elegant/fresh.css
@@ -43,50 +43,25 @@ li.current {
   margin-left: .362em;
   text-decoration: none;
 }
-fieldset {
-  border-radius: 4px;
-  border-width: 1px;
-}
-fieldset legend {
-  left: 0;
-  padding-bottom: 4px;
-  margin-bottom: 0;
-}
 textarea {
-  padding: 4px;
-  font-size: 12px;
-  line-height: 1.42857;
   color: #555;
   background-color: #fff;
   background-image: none;
   border: 1px solid #ccc;
-  border-radius: 4px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, .075) inset;
   transition: all .15s ease-in-out 0s;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-  width: 100%;
 }
 textarea:focus, textarea.focus {
   border: solid 1px #707070;
   box-shadow: 0 0 5px 1px #969696;
 }
 input {
-  padding: 4px;
-  font-size: 12px;
-  line-height: 1.42857;
   color: #555;
   background-color: #fff;
   background-image: none;
   border: 1px solid #ccc;
-  border-radius: 4px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, .075) inset;
   transition: all .15s ease-in-out 0s;
-}
-input.button {
-  box-shadow: 2px 2px 2px #808080;
-  border-color: #ccc;
 }
 input[name='apply_button'] {
   background: none repeat scroll 0 0 #696969;
@@ -129,47 +104,27 @@ input.button, input.button:hover {
 input.button[disabled] {
   cursor: default;
   opacity: .6;
-  box-shadow: none;
 }
-input.num {
-  vertical-align: middle;
+input.button[disabled]:hover {
+  border-color: transparent;
 }
 input.num[name*='lease'][size='10'] {
   margin-right: 4px;
 }
 select {
-  padding: 4px 4px;
-  font-size: 12px;
-  height: 1.6rem;
   color: #555;
   background-color: #fff;
   background-image: none;
   border: 1px solid #ccc;
-  border-radius: 4px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, .075) inset;
   transition: border-color .15s ease-in-out 0s, box-shadow .15s ease-in-out 0s;
-  vertical-align: middle;
 }
 button:hover, button:focus {
   color: #333;
-  text-decoration: none;
 }
 button {
-  display: inline-block;
-  margin-bottom: 0;
-  font-weight: normal;
-  text-align: center;
-  vertical-align: middle;
-  cursor: pointer;
   background-image: none;
   border: 1px solid transparent;
-  white-space: nowrap;
-  padding: 6px 12px;
-  font-size: 12px;
-  line-height: 1.42857;
-  border-radius: 4px;
-  -moz-user-select: none;
-  user-select: none;
 }
 .progressbar {
   background-color: #fff;
@@ -188,36 +143,20 @@ button {
   margin-bottom: 1em;
   border: 1px solid #111;
 }
-table[summary='ports forwarding table'] .num[size='15'] {
-  max-width: 100px;
-}
-table[summary='ports forwarding table'] .num[size='5'] {
-  max-width: 50px;
-}
-table[summary='ports forwarding table'] input[size='10'] {
-  max-width: 79px;
-}
-form[name='wds'] select {
-  margin-right: 6px;
-}
 #header {
   height: 9.24em;
 }
 .message {
-  border-radius: 6px;
+  background: #ccc;
+  border: 1px solid #ddd;
+}
+.popup {
+  background: #f9f9f9;
 }
 .meter {
-  border-radius: 3px;
-  border-width: 1px;
-}
-.progressbar {
-  border-radius: 4px;
-}
-.warning {
-  border-radius: 4px;
-  border-width: 2px;
+  background: #aaa;
+  border: 1px solid #888;
 }
 .odd {
   background-color: #f1f1f1;
-  border-radius: 2px;
 }

--- a/src/router/kromo/dd-wrt/elegant/style.css
+++ b/src/router/kromo/dd-wrt/elegant/style.css
@@ -42,15 +42,20 @@ input.button {
   border: 1px solid #30519c;
   color: #fff;
 }
-input.button:not([disabled]):hover {
+input.button:hover {
   background: #6384cf;
   border: 1px solid #6384cf;
+  color: #fff;
+}
+input.button[disabled]:hover {
+  background: #30519c;
+  border: 1px solid #30519c;
   color: #fff;
 }
 input[name*='refresh'][style*='background'] {
   background: #30519c !important;
 }
 input:focus-visible, textarea:focus-visible {
-  box-shadow: 0 0 5px 1px #6384cf !important;
-  outline: 2px solid #6384cf !important;
+  box-shadow: 0 0 5px 1px #6384cf;
+  outline: 2px solid #6384cf;
 }

--- a/src/router/kromo/dd-wrt/elegant/style.css
+++ b/src/router/kromo/dd-wrt/elegant/style.css
@@ -30,10 +30,6 @@ fieldset legend {
 .meter .text {
   color: #fff;
 }
-.progressbar {
-  background-color: #fff;
-  border-color: #999;
-}
 .progressbarblock {
   background-color: #6384cf;
 }

--- a/src/router/kromo/dd-wrt/green/style.css
+++ b/src/router/kromo/dd-wrt/green/style.css
@@ -30,10 +30,6 @@ fieldset legend {
 .meter .text {
   color: #fff;
 }
-.progressbar {
-  background-color: #fff;
-  border-color: #999;
-}
 .progressbarblock {
   background-color: #3b3;
 }

--- a/src/router/kromo/dd-wrt/green/style.css
+++ b/src/router/kromo/dd-wrt/green/style.css
@@ -40,17 +40,22 @@ fieldset legend {
 input.button {
   background: #3b3;
   border: 1px solid #3b3;
-  color: #111;
+  color: #000;
 }
-input.button:not([disabled]):hover {
+input.button:hover {
   background: #6c6;
   border: 1px solid #6c6;
+  color: #000;
+}
+input.button[disabled]:hover {
+  background: #3b3;
+  border: 1px solid #3b3;
   color: #000;
 }
 input[name*='refresh'][style*='background'] {
   background: #3b3 !important;
 }
 input:focus-visible, textarea:focus-visible {
-  box-shadow: 0 0 5px 1px #6c6 !important;
-  outline: 2px solid #6c6 !important;
+  box-shadow: 0 0 5px 1px #6c6;
+  outline: 2px solid #6c6;
 }

--- a/src/router/kromo/dd-wrt/orange/style.css
+++ b/src/router/kromo/dd-wrt/orange/style.css
@@ -39,16 +39,23 @@ fieldset legend {
 }
 input.button {
   background: #ff8400;
-  color: #111;
+  border: 1px solid #ff8400;
+  color: #000;
 }
-input.button:not([disabled]):hover {
+input.button:hover {
   background: #ff9000;
+  border: 1px solid #ff9000;
+  color: #000;
+}
+input.button[disabled]:hover {
+  background: #ff8400;
+  border: 1px solid #ff8400;
   color: #000;
 }
 input[name*='refresh'][style*='background'] {
   background: #ff8400 !important;
 }
 input:focus-visible, textarea:focus-visible {
-  box-shadow: 0 0 5px 1px #ff9000 !important;
-  outline: 2px solid #ff9000 !important;
+  box-shadow: 0 0 5px 1px #ff9000;
+  outline: 2px solid #ff9000;
 }

--- a/src/router/kromo/dd-wrt/orange/style.css
+++ b/src/router/kromo/dd-wrt/orange/style.css
@@ -30,10 +30,6 @@ fieldset legend {
 .meter .text {
   color: #fff;
 }
-.progressbar {
-  background-color: #fff;
-  border-color: #999;
-}
 .progressbarblock {
   background-color: #ff8400;
 }

--- a/src/router/kromo/dd-wrt/red/style.css
+++ b/src/router/kromo/dd-wrt/red/style.css
@@ -38,20 +38,24 @@ fieldset legend {
   background-color: #d55;
 }
 input.button {
+  background: #c00;
+  border: 1px solid #c00;
+  color: #fff;
+}
+input.button:hover {
   background: #d55;
   border: 1px solid #d55;
-  color: #fcc;
+  color: #fff;
 }
-input.button:not([disabled]):hover {
-  background: #e77;
-  border: 1px solid #e77;
+input.button[disabled]:hover] {
+  background: #c00;
+  border: 1px solid #c00;
   color: #fff;
 }
 input[name*='refresh'][style*='background'] {
   background: #d55 !important;
 }
 input:focus-visible, textarea:focus-visible {
-  box-shadow: 0 0 5px 1px #e77 !important;
-  outline: 2px solid #e77 !important;
+  box-shadow: 0 0 5px 1px #e77;
+  outline: 2px solid #e77;
 }
-

--- a/src/router/kromo/dd-wrt/red/style.css
+++ b/src/router/kromo/dd-wrt/red/style.css
@@ -30,10 +30,6 @@ fieldset legend {
 .meter .text {
   color: #fff;
 }
-.progressbar {
-  background-color: #fff;
-  border-color: #999;
-}
 .progressbarblock {
   background-color: #d55;
 }

--- a/src/router/kromo/dd-wrt/yellow/style.css
+++ b/src/router/kromo/dd-wrt/yellow/style.css
@@ -30,10 +30,6 @@ fieldset legend {
 .meter .text {
   color: #000;
 }
-.progressbar {
-  background-color: #fff;
-  border-color: #999;
-}
 .progressbarblock {
   background-color: #ffd700;
 }

--- a/src/router/kromo/dd-wrt/yellow/style.css
+++ b/src/router/kromo/dd-wrt/yellow/style.css
@@ -42,10 +42,15 @@ input.button {
   border: 1px solid #eec900;
   color: #1f1f03;
 }
-input.button:not([disabled]):hover {
+input.button:hover {
   background: #ffd700;
-  border: 1px solid #ffd700;
+  border: 1px solid #fdd700;
   color: #000;
+}
+input.button[disabled]:hover {
+  background: #eec900;
+  border: 1px solid #eec900;
+  color: #1f1f03;
 }
 input[name*='refresh'][style*='background'] {
   background: #eec900 !important;


### PR DESCRIPTION
## Notice
mainly only https://github.com/mirror/dd-wrt/commit/d305c0f06ec05ba03d7c9c329998052ef5b9b87e needs really revising
this is because properties were moved from `fresh.css` to `common.css`, since common is the file that is the layout mother and all other files are styling only (or should be in this case.)

It is the last commit on purpose and should be merged separately in case it needs reverting? I dont expect it will bu my eyes could have missed something.

---

https://github.com/mirror/dd-wrt/commit/38231240bb1829ff97ed5c2a21a24c1af01986af de-duplicates more extra entries
since they are common color properties fresh.css is the right place
fresh dark overrides these already as it should.

---.

https://github.com/mirror/dd-wrt/commit/551ecdecbc490890f31cdece610463161fcc58d0 belong with https://github.com/mirror/dd-wrt/commit/766452ad81770568e30ea7fcfd09af297c1b85d5

I noticed an issue Linux side where a rule is taking over `input.button:not([disaled]):hover` and it applies over all buttons.
Windows side nothing of the kind, in any case its better this way for now.

Until I test a build that is.

@BrainSlayer please review