### PR TITLE
WireGuard fix and cleanup

### DIFF
--- a/src/router/eop-tunnel/eop-tunnel-raip.sh
+++ b/src/router/eop-tunnel/eop-tunnel-raip.sh
@@ -1,12 +1,5 @@
 #!/bin/sh
 nv=/usr/sbin/nvram
-
-#debug
-deb=$(nvram get console_debug)
-if [[ $deb -eq 1 ]]; then
-	set -x
-fi
-
 i=$1
 fset=$2
 # egc Start with PBR to make sure killswitch is working

--- a/src/router/eop-tunnel/eop-tunnel.firewall
+++ b/src/router/eop-tunnel/eop-tunnel.firewall
@@ -2,13 +2,6 @@
 nv=/usr/sbin/nvram
 ipt=/usr/sbin/iptables
 tunnels=`$nv get oet_tunnels`
-
-#debug
-deb=$(nvram get console_debug)
-if [[ $deb -eq 1 ]]; then
-	set -x
-fi
-
 #WAN_IF="$(ip route | awk '/^default/{print $NF}')"
 WAN_IF=$(get_wanface)
 FW_STATE="-m state --state NEW"

--- a/src/router/eop-tunnel/eop-tunnel.prewall
+++ b/src/router/eop-tunnel/eop-tunnel.prewall
@@ -1,12 +1,6 @@
 #!/bin/sh
 nv=/usr/sbin/nvram
 /bin/mkdir -p /tmp/oet/pid
-
-#debug
-deb=$(nvram get console_debug)
-if [[ $deb -eq 1 ]]; then
-	set -x
-fi
 cd /tmp/oet/pid
 rmmod eoip >/dev/null 2>&1
 tunnels=`$nv get oet_tunnels`

--- a/src/router/wireguard/wireguard-fwatchdog.sh
+++ b/src/router/wireguard/wireguard-fwatchdog.sh
@@ -1,9 +1,4 @@
 #!/bin/sh
-#debug
-deb=$(nvram get console_debug)
-if [[ $deb -eq 1 ]]; then
-	set -x
-fi
 i=$1
 [[ -z "$i" ]] && i=1
 SLEEP=$2
@@ -36,9 +31,9 @@ while sleep $SLEEP; do
 					nvram set oet${i}_failstate=0
 				done
 			fi
-			/etc/config/eop-tunnel.prewall  >/dev/null 2>&1
-			/etc/config/eop-tunnel.firewall  >/dev/null 2>&1
-		fi	
+			sh /usr/bin/wireguard-restart.sh &
+			exit
+		fi
 		break
 	done
 done

--- a/src/router/wireguard/wireguard-restart.sh
+++ b/src/router/wireguard/wireguard-restart.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+/etc/config/eop-tunnel.prewall  >/dev/null 2>&1
+logger -p user.info "WireGuard watchdog: tunnel restarted"
+sleep 1
+/etc/config/eop-tunnel.firewall  >/dev/null 2>&1
+logger -p user.info "WireGuard watchdog: firewall restarted"


### PR DESCRIPTION
Thanks for implementing the WireGuard updates

During testing I found a bug, the watchdog script restarts the tunnel but  when the tunnel restarts there is a thorough clean up also from running watchdog scripts.
Depending on how fast etc, the watchdog script can kill itself before it is finished.
So I had to spawn the restart process.
Also did some cleaning 😊
Attached the fix 
Vielen Dank/Thanks

I also mailed the patch to you already