### PR TITLE
font size to em

### DIFF
--- a/src/router/httpd/visuals/ejs.c
+++ b/src/router/httpd/visuals/ejs.c
@@ -2295,7 +2295,7 @@ EJ_VISIBLE void ej_do_hpagehead(webs_t wp, int argc, char_t ** argv)	// Eko
 		websWrite(wp, "  line-height: 1.7em;\n");
 		websWrite(wp, "}\n");
 		websWrite(wp, "body {\n");
-		websWrite(wp, "  font-size: 69%%;\n");
+		websWrite(wp, "  font-size: .75em;\n");
 		websWrite(wp, "  margin: .906em;\n");
 		websWrite(wp, "}\n");
 		websWrite(wp, ".t-border {\n");

--- a/src/router/kromo/dd-wrt/common_style/common.css
+++ b/src/router/kromo/dd-wrt/common_style/common.css
@@ -4,7 +4,7 @@
 }
 body {
   margin: .906em;
-  font-size: 69%;
+  font-size: .75em;
 }
 /*! Common to light and dark for now */
 body.gui {

--- a/src/router/kromo/dd-wrt/common_style/common_help.css
+++ b/src/router/kromo/dd-wrt/common_style/common_help.css
@@ -5,7 +5,7 @@
 }
 body {
   margin: .906em;
-  font-size: 69%;
+  font-size: .75em;
 }
 tt {
   font-family: Courier, 'Courier New';


### PR DESCRIPTION
this is based on 12px since we try to support a wide range of devices 
and default browser font-sizes

Firefox by default uses 16px

this solves an issue where font-size: 69% vs browser font sizes makes svg's go out of bounds like the graph banndwidth monitor for instance.