### PR TITLE
try to handle cpu feat lines that wrap w/o left indent

### DIFF
--- a/src/router/httpd/visuals/cpucores.c
+++ b/src/router/httpd/visuals/cpucores.c
@@ -333,7 +333,7 @@ static struct CPUFEATURES cpufeatures[] = {
 	{ "Features", "crunch", "CRUNCH" },
 	{ "Features", "idiva", "IDIVA" },
 	{ "Features", "idivt", "IDIVT" },
-//	{ "Features", "evtstrm", "EVTSTRM" },
+	{ "Features", "evtstrm", "EVTSTRM" },
 //mips
 
 /*	{"isa", "mips1", "MIPS1"},
@@ -403,7 +403,7 @@ EJ_VISIBLE void ej_show_cpufeatures(webs_t wp, int argc, char_t ** argv)
 		char buf[128];
 		websWrite(wp, "<div class=\"setting\">\n");
 		websWrite(wp, "<div class=\"label\">%s</div>\n", tran_string(buf, sizeof(buf), "status_router.features"));
-		websWrite(wp, "%s&nbsp;\n", result);
+		websWrite(wp, "<div class=\"cpu-feat\">%s&nbsp;\n</div>", result);
 		websWrite(wp, "</div>\n");
 	}
 	if (result)

--- a/src/router/kromo/dd-wrt/common_style/common.css
+++ b/src/router/kromo/dd-wrt/common_style/common.css
@@ -270,6 +270,9 @@ h2, h3 {
   right: 0;
   width: 19em;
 }
+.cpu-feat {
+  padding-left: 13.6rem;
+}
 .warning {
   padding: .725em;
   text-align: center;


### PR DESCRIPTION
To fix these issues, where the cpu features result is so long that wrapping entries aren't left indented since they are rendered inside the `<div class="settings">, via CSS without further changes tweaking the `.settings/.lable class` will affect both, and is unmaintainable.

Displaying such results in own class, would allow for instance responsive design implementation in future, since manipulating the result via CSS wont interfere with the setting or label. (just requires extending this principle where needed)

![Capture](https://forum.dd-wrt.com/phpBB2/files/screenshot_2022_04_02_at_23_14_30_orthanc_build_48567__router_status_159.png)

I did a POC in browser hack but I hope this will not render each feature in separate divs, I hope it works like browser hack, else, its a back to drawing board and I cant draw C source on any board.

![Capture](https://user-images.githubusercontent.com/31389848/162573837-c3cd7d05-3f54-4258-92e1-8dcd8dd26ec0.PNG)

