### PR TITLE
UPnP IGD: Improve wording and UI

### DIFF
--- a/src/router/kromo/dd-wrt/UPnP.asp
+++ b/src/router/kromo/dd-wrt/UPnP.asp
@@ -67,7 +67,7 @@ function setUPnPTable(forwards) {
 		//proto
 		var cell = row.insertCell(-1);
 		cell.innerHTML = data[i].proto;
-		cell.align = "center";
+		cell.align = "left";
 
 		row.style.height = "15px";
 		row.className = (data[i].enabled ? '' : 'disabled');
@@ -84,7 +84,7 @@ function setUPnPTable(forwards) {
 function deleteForward(x) {
 	if (x != 'all') {
 		var e = data[x];
-		if (!confirm(share.del + " " + e.desc + "? [" + e.wanPorts + "->" + e.lanPorts + " " + e.lanIP + " " + e.proto + "]")) return;
+		if (!confirm(share.del + " " + e.lanIP + ":" + e.lanPorts + "/" + e.proto + " (" + e.desc + ")?")) return;
 	}
 	else {
 		if (!confirm(upnp.msg2)) return;
@@ -152,11 +152,11 @@ addEvent(window, "unload", function() {
 								<table class="table" cellspacing="6" id="upnp_table" summary="UPnP table">
 									<tbody>
 									<tr>
-										<th width="10%" class="center"><% tran("share.ip"); %></th>
-										<th width="5%" class="center"><% tran("share.from2"); %>&nbsp;(WAN)</th>
-										<th width="5%" class="center"><% tran("share.to2"); %>&nbsp;(LAN)</th>
-										<th width="5%" class="center"><% tran("share.proto"); %></th>
-										<th width="30%" class="center"><% tran("share.descr"); %></th>
+										<th width="10%"><% tran("share.ip"); %></th>
+										<th width="7%"><% tran("pforward.from"); %></th>
+										<th width="7%"><% tran("pforward.to"); %></th>
+										<th width="5%"><% tran("share.proto"); %></th>
+										<th width="30%"><% tran("share.descr"); %></th>
 										<th width="10%" class="center"><% tran("share.del"); %></th>
 									</tr>
 									</tbody>

--- a/src/router/kromo/dd-wrt/lang_pack/arabic.js
+++ b/src/router/kromo/dd-wrt/lang_pack/arabic.js
@@ -1409,12 +1409,11 @@ hupgrad.right2="Click on the <em>Browse...</em> button to select the firmware fi
 
 upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
-upnp.legend="Forwards";
+upnp.legend="Active Port Forwards";
 upnp.legend2="UPnP Configuration";
-upnp.serv="UPnP Service";
-upnp.url="Send presentation URL";
-upnp.msg1="Click to delete entry";
-upnp.msg2="Delete all entries?";
+upnp.serv="UPnP IGD Service";
+upnp.msg1="Click to delete port forward";
+upnp.msg2="Delete all port forwards?";
 
 //help container
 

--- a/src/router/kromo/dd-wrt/lang_pack/catalan.js
+++ b/src/router/kromo/dd-wrt/lang_pack/catalan.js
@@ -1628,8 +1628,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="Reenviaments";
 upnp.legend2="Configuració UPnP";
-upnp.serv="Servei UPnP";
-upnp.url="Envia el URL de presentació";
+upnp.serv="Servei UPnP IGD";
 upnp.msg1="Feu clic per suprimir una entrada";
 upnp.msg2="Suprimir totes les entrades?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/chinese_simplified.js
+++ b/src/router/kromo/dd-wrt/lang_pack/chinese_simplified.js
@@ -1837,8 +1837,7 @@ upnp.titl="UPnP";
 upnp.h2="通用即插即用（UPnP）";
 upnp.legend="转发";
 upnp.legend2="UPnP配置";
-upnp.serv="UPnP服务";
-upnp.url="发送网络发现URL";
+upnp.serv="UPnP IGD服务";
 upnp.msg1="点击删除条目";
 upnp.msg2="删除所有条目？";
 

--- a/src/router/kromo/dd-wrt/lang_pack/chinese_traditional.js
+++ b/src/router/kromo/dd-wrt/lang_pack/chinese_traditional.js
@@ -1392,8 +1392,7 @@ upnp.titl="UPnP";
 upnp.h2="通用即插即用 (UPnP)";
 upnp.legend="虛擬伺服器（映射）";
 upnp.legend2="UPnP設定";
-upnp.serv="UPnP伺服器";
-upnp.url="發布 UPnP網址";
+upnp.serv="UPnP IGD伺服器";
 upnp.msg1="刪除租用";
 upnp.msg2="刪除所有項目？";
 

--- a/src/router/kromo/dd-wrt/lang_pack/croatian.js
+++ b/src/router/kromo/dd-wrt/lang_pack/croatian.js
@@ -1546,8 +1546,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="Prosljeđivanje";
 upnp.legend2="Konfiguracija UPnP";
-upnp.serv="UPnP Usluga";
-upnp.url="Šalji prezentacijski URL";
+upnp.serv="UPnP IGD Usluga";
 upnp.msg1="Klikni za brisanje unosa";
 upnp.msg2="Brisati sve unose?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/czech.js
+++ b/src/router/kromo/dd-wrt/lang_pack/czech.js
@@ -2296,8 +2296,7 @@ upnp.titl="UPnP";
 upnp.h2="Universální Plug & Play (UPnP)";
 upnp.legend="Předávání";
 upnp.legend2="UPnP Konfigurace";
-upnp.serv="Služba UPnP";
-upnp.url="Odeslat prezentační URL";
+upnp.serv="Služba UPnP IGD";
 upnp.msg1="Kliknutím odeberte položku";
 upnp.msg2="Odebrat všechny položky?";
 
@@ -2310,8 +2309,7 @@ hupnp.right4="Umožňuje aplikacím automaticky konfigurovat předávání port�
 hupnp.page1="<dd>Universální Plug and Play (UPnP) je sada počítačových síťových protokolů. Tato technologie společnosti Microsoft je pro automatickou konfiguraci zařízení. Cílem UPnP je umožnit zařízením bezproblémové připojení a zjednodušení implementace sítě v domácím a podnikovém prostředí. UPnP toho dosahuje definováním a publikováním protokolů řízení zařízení UPnP založených na otevřených komunikačních standardech založených na internetu.</dd>";
 hupnp.page2="<dd>Tabulka předávání UPnP zobrazuje všechny otevřené porty, které byly automaticky předávány procesem UPnP. Můžete odebrat předávání kliknutím na koš nebo kliknutím na tlačítko <em>Odebrat vše</em> a všechny předávání odebrat.</dd>";
 hupnp.page3="<dd>Umožňuje aplikacím automaticky nastavit předávání portů.</dd>";
-hupnp.page4="<dd>Pokud je povoleno, budou při spuštění Routeru odstraněna všechna předávání portů UPnP.</dd>";
-hupnp.page5="<dd>Je-li povoleno, je odesílána značka URL prezentace s popisem zařízení. To umožňuje, aby se Router zobrazil v <em>Místa v síti Windows</em>. <br /><br />div class=\"note\"><h4>Poznámka</h4><div>Když povolíte tuto možnost, budete možná muset restartovat počítač.</div></div></dd><dd>Klikněte na <i>Uložit nastavení</i> pro uložení nastavení. Kliknutím na <i>Zrušit změny</i> zrušíte neuložené změny.</dd>";
+
 // ** VPN.asp **//
 //
 vpn.titl="Průchody VPN";

--- a/src/router/kromo/dd-wrt/lang_pack/dutch.js
+++ b/src/router/kromo/dd-wrt/lang_pack/dutch.js
@@ -1529,8 +1529,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug en Play (UPnP)";
 upnp.legend="Forwards";
 upnp.legend2="UPnP Configuratie";
-upnp.serv="UPnP Service";
-upnp.url="Presentatie URL zenden";
+upnp.serv="UPnP IGD Service";
 upnp.msg1="Klik om de waarde te verwijderen";
 upnp.msg2="Alle waarden verwijderen?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/english.js
+++ b/src/router/kromo/dd-wrt/lang_pack/english.js
@@ -2615,12 +2615,11 @@ hupgrad.page1="<dd>New firmware versions are posted at <a href=\"https:\/\/dd-wr
 var upnp=new Object();
 upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
-upnp.legend="Forwards";
+upnp.legend="Active Port Forwards";
 upnp.legend2="UPnP Configuration";
-upnp.serv="UPnP Service";
-upnp.url="Send presentation URL";
-upnp.msg1="Click to delete entry";
-upnp.msg2="Delete all entries?";
+upnp.serv="UPnP IGD Service";
+upnp.msg1="Click to delete port forward";
+upnp.msg2="Delete all port forwards?";
 
 //help container
 var hupnp=new Object();
@@ -2631,8 +2630,6 @@ hupnp.right4="Allows applications to automatically configure port forwarding.";
 hupnp.page1="<dd>Also known as UPnP it is a set of network protocols used for the automatic configuration of devices. The goals of UPnP are to allow devices to connect seamlessly and to simplify the implementation of home or corporate environment networks. UPnP achieves this by defining and publishing device control protocols built upon open, Internet-based communication standards.</dd>";
 hupnp.page2="<dd>The UPnP forwards table shows all open ports forwarded automatically by the UPnP process. You can delete forwards by clicking <i>remove icon</i> or the <em>" + sbutton.delall + "</em> button to clear the undesired entries.</dd>";
 hupnp.page3="<dd>Allows applications to automatically setup port forwarding rules.</dd>";
-hupnp.page4="<dd>If enabled, all UPnP port forwarding rules are deleted when the router starts up.</dd>";
-hupnp.page5="<dd>If enabled, a presentation URL tag is sent with the device description. This allows the router to show up in <em>Windows's My Network Places</em>.<br /><br />div class=\"note\"><h4>Note:</h4><div>When enabling this option you may need to reboot your computer.</div></div></dd><dd>Click the <em>" + sbutton.save + "</em> button to save your settings. Click the <em>" + sbutton.cancel + "</em> button to cancel your unsaved changes.</dd>";
 
 // ** VPN.asp **//
 var vpn=new Object();

--- a/src/router/kromo/dd-wrt/lang_pack/french.js
+++ b/src/router/kromo/dd-wrt/lang_pack/french.js
@@ -1306,8 +1306,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="Listes redirections UPnP";
 upnp.legend2="Configuration UPnP";
-upnp.serv="Service UPnP";
-upnp.url="Présentation URL";
+upnp.serv="Service UPnP IGD";
 upnp.msg1="Cliquez pour supprimer la redirection";
 upnp.msg2="Êtes-vous sûr de vouloir effacer toutes les règles UPNP ?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/german.js
+++ b/src/router/kromo/dd-wrt/lang_pack/german.js
@@ -2300,12 +2300,11 @@ hupgrad.right2="Klicken Sie auf den <em>Durchsuchen...</em>-Button, um eine Firm
 
 upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
-upnp.legend="Weiterleitungen";
+upnp.legend="Aktive Port-Weiterleitungen";
 upnp.legend2="UPnP-Konfiguration";
-upnp.serv="UPnP-Dienst";
-upnp.url="Sende Präsentations-URL";
-upnp.msg1="Klicken Sie hier, um die Lease zu löschen";
-upnp.msg2="Alle Einträge löschen?";
+upnp.serv="UPnP IGD Dienst";
+upnp.msg1="Klicken Sie hier, um die Port-Weiterleitung zu löschen";
+upnp.msg2="Alle Port-Weiterleitungen löschen?";
 
 //help container
 

--- a/src/router/kromo/dd-wrt/lang_pack/hungarian.js
+++ b/src/router/kromo/dd-wrt/lang_pack/hungarian.js
@@ -1257,8 +1257,7 @@ upnp.titl="UPnP";
 upnp.h2="Univerzális Plug and Play (UPnP)";
 upnp.legend="Továbbítások";
 upnp.legend2="UPnP beállítása";
-upnp.serv="UPnP szolgáltatás";
-upnp.url="Bemutató (Presentation) URL küldése";
+upnp.serv="UPnP IGD szolgáltatás";
 upnp.msg1="Kattintson ide a bejegyzés törléséhez!";
 upnp.msg2="Törli az összes bejegyzést?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/italian.js
+++ b/src/router/kromo/dd-wrt/lang_pack/italian.js
@@ -1984,8 +1984,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="Forward";
 upnp.legend2="Configurazione UPnP";
-upnp.serv="Servizio UPnP";
-upnp.url="Invia la presentazione dell' URL";
+upnp.serv="Servizio UPnP IGD";
 upnp.msg1="Clicca per cancellare la riga";
 upnp.msg2="Cancella tutte le righe?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/japanese.js
+++ b/src/router/kromo/dd-wrt/lang_pack/japanese.js
@@ -1553,8 +1553,7 @@ upnp.titl="UPnP";
 upnp.h2="UPnP設定";
 upnp.legend="ポート変換リスト";
 upnp.legend2="UPnP 設定";
-upnp.serv="UPnP サービス";
-upnp.url="Presentation URLを送る";
+upnp.serv="UPnP IGD サービス";
 upnp.msg1="消去";
 upnp.msg2="すべて消去してもよろしいですか？";
 

--- a/src/router/kromo/dd-wrt/lang_pack/korean.js
+++ b/src/router/kromo/dd-wrt/lang_pack/korean.js
@@ -1744,8 +1744,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="포워드 리스트";
 upnp.legend2="UPnP 설정";
-upnp.serv="UPnP 서비스";
-upnp.url="프레젠테이션 URL 전송";
+upnp.serv="UPnP IGD 서비스";
 upnp.msg1="클릭하면 포워드 리스트가 삭제됩니다";
 upnp.msg2="모든 포워드 리스트를 삭제할까요?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/polish.js
+++ b/src/router/kromo/dd-wrt/lang_pack/polish.js
@@ -2327,8 +2327,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="Przekierowania";
 upnp.legend2="Konfiguracja UPnP";
-upnp.serv="Usługa UPnP";
-upnp.url="Prześlij adres URL prezentacji";
+upnp.serv="Usługa UPnP IGD";
 upnp.msg1="Kliknij, aby usunąć wpis";
 upnp.msg2="Usunąć wszystkie wpisy?";
 
@@ -2341,8 +2340,6 @@ hupnp.right4="Allows applications to automatically configure port forwarding.";
 hupnp.page1="<dd>Universal Plug and Play (UPnP) is a set of computer network protocols. This Microsoft technology is for automatic configuration of devices. The goals of UPnP are to allow devices to connect seamlessly and to simplify the implementation of networks in the home and corporate environments. UPnP achieves this by defining and publishing UPnP device control protocols built upon open, Internet-based communication standards.</dd>";
 hupnp.page2="<dd>The UPnP forwards table shows all open ports forwarded automatically by the UPnP process. You can delete forwards by clicking the trash can or click the <em>Delete All</em> button to clear all forwards.</dd>";
 hupnp.page3="<dd>Allows applications to automatically setup port forwarding rules.</dd>";
-hupnp.page4="<dd>If enabled, all UPnP port forwarding rules are deleted when the router starts up.</dd>";
-hupnp.page5="<dd>If enabled, a presentation URL tag is sent with the device description. This allows the router to show up in <em>Windows's My Network Places</em>. <br /><br />div class=\"note\"><h4>Note</h4><div>When enabling this option you may need to reboot your PC.</div></div></dd><dd>Click <i>Save Settings</i> to save your settings. Click <i>Cancel Changes</i> to cancel your unsaved changes.</dd>";
 
 // ** VPN.asp **//
 

--- a/src/router/kromo/dd-wrt/lang_pack/portuguese_braz.js
+++ b/src/router/kromo/dd-wrt/lang_pack/portuguese_braz.js
@@ -1741,8 +1741,7 @@ upnp.titl="UPnP";
 upnp.h2="Plug and Play Universal (UPnP)";
 upnp.legend="Encaminhamentos";
 upnp.legend2="Configurações UPnP";
-upnp.serv="Serviço UPnP";
-upnp.url="Enviar URL de apresentação";
+upnp.serv="Serviço UPnP IGD";
 upnp.msg1="Clique para apagar a entrada";
 upnp.msg2="Remover todas as entradas?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/romanian.js
+++ b/src/router/kromo/dd-wrt/lang_pack/romanian.js
@@ -1679,8 +1679,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="Înaintări";
 upnp.legend2="Configurare UPnP";
-upnp.serv="Serviciu UPnP";
-upnp.url="Trimite URL de prezentare";
+upnp.serv="Serviciu UPnP IGD";
 upnp.msg1="Clic pentru a șterge intrarea";
 upnp.msg2="Ștergeți toate intrările?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/russian.js
+++ b/src/router/kromo/dd-wrt/lang_pack/russian.js
@@ -1680,8 +1680,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="Перенаправления";
 upnp.legend2="Конфигурация UPnP";
-upnp.serv="Служба UPnP";
-upnp.url="Послать презентационный URL";
+upnp.serv="Служба UPnP IGD";
 upnp.msg1="Щелкните здесь для удаления записи";
 upnp.msg2="Удалить все записи?";
 //help container

--- a/src/router/kromo/dd-wrt/lang_pack/serbian.js
+++ b/src/router/kromo/dd-wrt/lang_pack/serbian.js
@@ -1746,8 +1746,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="Прослеђивања";
 upnp.legend2="UPnP Конфигурација";
-upnp.serv="UPnP Услуга";
-upnp.url="Пошаљи URL за представљање";
+upnp.serv="UPnP IGD Услуга";
 upnp.msg1="Кликните да бисте обрисали унос";
 upnp.msg2="Обрисати све уносе?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/slovenian.js
+++ b/src/router/kromo/dd-wrt/lang_pack/slovenian.js
@@ -1732,8 +1732,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="Posredovanja";
 upnp.legend2="Konfiguracija UPnP";
-upnp.serv="UPnP storitev";
-upnp.url="Pošlji predstavitveni URL";
+upnp.serv="UPnP IGD storitev";
 upnp.msg1="Kliknite za izbris vnosa";
 upnp.msg2="Izbrišem vse vnose?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/spanish.js
+++ b/src/router/kromo/dd-wrt/lang_pack/spanish.js
@@ -1556,8 +1556,7 @@ upnp.titl="UPnP";
 upnp.h2="Universal Plug and Play (UPnP)";
 upnp.legend="Redirección";
 upnp.legend2="Configuración UPnP";
-upnp.serv="Servicio UPnP";
-upnp.url="Enviar URL de Presentación";
+upnp.serv="Servicio UPnP IGD";
 upnp.msg1="Clic para borrar Lease";
 upnp.msg2="¿Borrar Entradas?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/swedish.js
+++ b/src/router/kromo/dd-wrt/lang_pack/swedish.js
@@ -1500,8 +1500,7 @@ upnp.titl="UPnP";
 upnp.h2="Universell Plug and Play (UPnP)";
 upnp.legend="Forwards";
 upnp.legend2="UPnP Konfig";
-upnp.serv="UPnP Tjänst";
-upnp.url="Sänd Presentations URL";
+upnp.serv="UPnP IGD Tjänst";
 upnp.msg1="Klicka för att radera ";
 upnp.msg2="Radera alla rader?";
 

--- a/src/router/kromo/dd-wrt/lang_pack/turkish.js
+++ b/src/router/kromo/dd-wrt/lang_pack/turkish.js
@@ -1587,8 +1587,7 @@ upnp.titl="UPnP";
 upnp.h2="Evrensel Tak ve Kullan (UPnP)";
 upnp.legend="Yönlendirmeler";
 upnp.legend2="UPnP Yapılandırması";
-upnp.serv="UPnP Servisi";
-upnp.url="Sunum URL'si gönder";
+upnp.serv="UPnP IGD Servisi";
 upnp.msg1="Girişi silmek için tıkla";
 upnp.msg2="Tüm girişler silinsin mi?";
 


### PR DESCRIPTION
- Remove `Enabled` table column as only enabled are shown and rearrange columns

Fixed in 8df0f4a eff5989 02eb8ff 3409e87

- Remove `Clear Port Forwards at Startup` as it is always cleared

Fixed in 64d27e6 2d430f0

- Left-align table headings to match the rest of the port forwarding tables and content, and describe it more clearly as `Active Port Forwards` rather than just `Forwards`
- Use same wording (`Port From`/`Port To`) as in `Port Forwarding`
- Use `UPnP IGD` to describe the protocol in more detail, as UPnP is also used for many services, e.g. media servers, and this newer/shorter wording is used in other router projects
- Remove unused strings in `lang_pack`

![dd-wrt](https://github.com/user-attachments/assets/09706817-4984-4e12-85c8-e1fe5e6a1fbe)
_[Screenshot 2024-10 beta release](https://github.com/user-attachments/assets/70ef18cd-5243-4319-8379-4f26b119dcf2)_

The **Port Control Protocol (PCP)** is the successor to NAT-PMP, has similar protocol concepts and packet formats, but adds support for **IPv6 port maps** and options/extensions. For more information, see:
**Port Mapping Protocols Overview and Comparison 2024: About UPnP IGD & PCP/NAT-PMP**
https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview